### PR TITLE
chore: Update npm scripts for test coverage and server

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prisma:migrate": "prisma migrate dev",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage && http-server public/coverage/lcov-report"
+    "test:coverage": "jest --coverage",
+    "coverage:server": " http-server public/coverage/lcov-report"
   },
   "dependencies": {
     "@mozilla/readability": "^0.5.0",


### PR DESCRIPTION
Updates the `test:coverage` npm script to remove the unnecessary command for starting a local server. Adds a new npm script `coverage:server` to start a server for viewing the coverage report generated by Jest.

Note: This commit message includes additional information for clarity. Please remove any unnecessary details before using the commit message.