### PR TITLE
Fix getPostPages negative length bug

### DIFF
--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -28,6 +28,14 @@ describe("Testing /api/getPostPages function", () => {
       { params: { page: "4" } },
     ]);
   });
+
+  test("should return an empty array when there is only one page", async () => {
+    (prismaMock.post.count as jest.Mock).mockResolvedValue(20);
+
+    const pages = await getPostPages();
+
+    expect(pages).toEqual([]);
+  });
 });
 
 describe("Testing /api/getPostSlugs function", () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,7 +12,7 @@ export const getPostPages = async () => {
   const perPage = PER_PAGE;
   const totalPosts = await prisma.post.count();
 
-  const numberOfPages = Math.ceil(totalPosts / perPage) - 1; // -1 to exclude the first page, which is the index page
+  const numberOfPages = Math.max(0, Math.ceil(totalPosts / perPage) - 1); // -1 to exclude the first page, which is the index page
 
   return Array.from({ length: numberOfPages }, (_, i) => ({
     params: {


### PR DESCRIPTION
## Summary
- avoid negative lengths when generating pages
- test new behavior for post count less than a page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f88beccb883269eafac006f8796ed